### PR TITLE
Change time arithmetic from wall time to monotonic time

### DIFF
--- a/drivers/staging/bcm/Adapter.h
+++ b/drivers/staging/bcm/Adapter.h
@@ -185,7 +185,7 @@ struct bcm_packet_info {
 	bool		bHeaderSuppressionEnabled;
 	spinlock_t	SFQueueLock;
 	void		*pstSFIndication;
-	struct timeval	stLastUpdateTokenAt;
+	ktime_t	stLastUpdateTokenAt;
 	atomic_t	uiPerSFTxResourceCount;
 	UINT		uiMaxLatency;
 	UCHAR		bIPCSSupport;

--- a/drivers/staging/bcm/headers.h
+++ b/drivers/staging/bcm/headers.h
@@ -35,6 +35,7 @@
 #include <linux/udp.h>
 #include <linux/usb.h>
 #include <linux/uaccess.h>
+#include <linux/ktime.h>
 #include <net/ip.h>
 
 #include "Typedefs.h"


### PR DESCRIPTION
Hi Matthias,

LeakyBucket.c uses wall clock time to do time arithmetic; it should rather use CLOCK_MONOTONIC_RAW to avoid unexpected issues such as negative time differences, etc. You can see this blog describing problems with using gettimeofday in user-space programs (https://blog.habets.se/2010/09/gettimeofday-should-never-be-used-to-measure-time)

I realise that bcm wimax is no longer being maintained in the main branch of kernel. But, we found this bug as part of a research project to find such bugs in kernel using static analysis. It will be extremely helpful if you could please confirm this.

Best Regards,
Abhilash Jindal,
PhD student,
Purdue University
